### PR TITLE
 feat(event-service): Implement Event Service creation and retrieval

### DIFF
--- a/event-service/pom.xml
+++ b/event-service/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.mck</groupId>
+        <artifactId>EventHorizon</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>event-service</artifactId>
+    <name>event-service</name>
+    <description>Microservice for Event Management</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/event-service/src/main/java/org/mck/eventservice/EventServiceApplication.java
+++ b/event-service/src/main/java/org/mck/eventservice/EventServiceApplication.java
@@ -1,0 +1,13 @@
+package org.mck.eventservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EventServiceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(EventServiceApplication.class, args);
+	}
+
+}

--- a/event-service/src/main/java/org/mck/eventservice/controller/EventController.java
+++ b/event-service/src/main/java/org/mck/eventservice/controller/EventController.java
@@ -1,0 +1,30 @@
+package org.mck.eventservice.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.mck.eventservice.domain.Event;
+import org.mck.eventservice.service.EventService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/v1/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService eventService;
+
+    @PostMapping
+    ResponseEntity<Event> createEvent(@RequestBody Event newEvent){
+        return ResponseEntity.ok(eventService.createEvent(newEvent));
+    }
+
+    @GetMapping
+    ResponseEntity<List<Event>> getAllEvents(){
+        List<Event> events = eventService.getAllEvents();
+        return ResponseEntity.ok(events);
+    }
+
+}

--- a/event-service/src/main/java/org/mck/eventservice/domain/Event.java
+++ b/event-service/src/main/java/org/mck/eventservice/domain/Event.java
@@ -1,0 +1,22 @@
+package org.mck.eventservice.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "events")
+@Data @NoArgsConstructor
+@AllArgsConstructor
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private LocalDate eventDate;
+    private Long  organizerUserId;
+}

--- a/event-service/src/main/java/org/mck/eventservice/repository/EventRepository.java
+++ b/event-service/src/main/java/org/mck/eventservice/repository/EventRepository.java
@@ -1,0 +1,9 @@
+package org.mck.eventservice.repository;
+
+import org.mck.eventservice.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event,Long> {
+}

--- a/event-service/src/main/java/org/mck/eventservice/service/EventService.java
+++ b/event-service/src/main/java/org/mck/eventservice/service/EventService.java
@@ -1,0 +1,37 @@
+package org.mck.eventservice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.mck.eventservice.domain.Event;
+import org.mck.eventservice.repository.EventRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final EventRepository eventRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public Event createEvent(Event event) {
+
+        String userServiceUrl = "http://localhost:8080/api/v1/users/" + event.getOrganizerUserId();
+
+        System.out.println(userServiceUrl);
+
+        try{
+            restTemplate.getForEntity(userServiceUrl, String.class);
+            return eventRepository.save(event);
+        }catch(HttpClientErrorException.NotFound ex){
+            throw new RuntimeException("Oganizador com ID " + event.getOrganizerUserId() + " não encontrado.");
+        }
+    }
+
+    public List<Event> getAllEvents() {
+        return eventRepository.findAll();
+    }
+
+}

--- a/event-service/src/main/resources/application.properties
+++ b/event-service/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.application.name=event-service
+server.port=8081
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 
     <modules>
         <module>user-service</module>
+        <module>event-service</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### Summary

This PR introduces the `event-service` module, establishing the first point of inter-service communication within the EventHorizon project.

### Key Changes

- **Bootstrap `event-service`:** Created the new module by adapting the structure from `user-service`.
- **Implement `POST /api/v1/events`:**
  - Allows for the creation of new events.
  - Before saving an event, it performs a validation check against the `user-service`.
- **Implement `GET /api/v1/events`:**
  - Allows for retrieving a list of all created events.
- **Inter-Service Communication:**
  - Implemented a direct REST call using `RestTemplate` from `EventService` to `user-service` (`GET /api/v1/users/{id}`).
  
### How to Test

1.  Ensure both `user-service` and `event-service` applications are running.
2.  Use a REST client (e.g., Postman) to `POST` a new user to `http://localhost:8080/api/v1/users`. Note the `id` returned.
3.  `POST` a new event to `http://localhost:8081/api/v1/events` using the `organizerUserId` from the previous step. The request should return `201 Created`.
4.  `POST` another new event using an invalid `organizerUserId` (e.g., 999). The request should fail with a server error, and the logs should indicate the organizer was not found.
5.  `GET` from `http://localhost:8081/api/v1/events` to verify the first event was created.